### PR TITLE
Add --arch flag to catalogs and iso:get

### DIFF
--- a/.mise/tasks/catalog/alpine
+++ b/.mise/tasks/catalog/alpine
@@ -15,7 +15,7 @@ ARCH=$(resolve_arch alpine "${usage_arch:-}") || { echo "Error: Alpine Linux doe
 
 fetch_version_detail() {
   local yaml
-  yaml=$(curl -fsSL "$MIRROR/v$VERSION/releases/$ARCH/latest-releases.yaml") || { echo "Error: version $VERSION not found." >&2; exit 1; }
+  yaml=$(curl -fsSL "$MIRROR/v$VERSION/releases/$ARCH/latest-releases.yaml") || { echo "Error: Alpine $VERSION not found for $ARCH. This distro may not publish ISOs for this architecture." >&2; exit 1; }
 
   echo "$yaml" | yq -o=json | jq --arg mirror "$MIRROR" --arg version "$VERSION" --arg arch "$ARCH" '
     [ .[] | select(.iso | test("\\.iso$")) | {

--- a/.mise/tasks/catalog/alpine
+++ b/.mise/tasks/catalog/alpine
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Show available Alpine Linux versions and variants"
 #USAGE flag "-v --version <version>" help="Show variants for a specific version"
+#USAGE flag "--arch <arch>" help="Architecture (default: host)" default=""
 #USAGE flag "--json" help="Output as JSON"
 set -euo pipefail
 
@@ -10,15 +11,17 @@ JSON="${usage_json:-false}"
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 
+ARCH=$(resolve_arch alpine "${usage_arch:-}") || { echo "Error: Alpine Linux does not publish ISOs for architecture '${usage_arch:-$(uname -m)}'." >&2; exit 1; }
+
 fetch_version_detail() {
   local yaml
-  yaml=$(curl -fsSL "$MIRROR/v$VERSION/releases/x86_64/latest-releases.yaml") || { echo "Error: version $VERSION not found." >&2; exit 1; }
+  yaml=$(curl -fsSL "$MIRROR/v$VERSION/releases/$ARCH/latest-releases.yaml") || { echo "Error: version $VERSION not found." >&2; exit 1; }
 
-  echo "$yaml" | yq -o=json | jq --arg mirror "$MIRROR" --arg version "$VERSION" '
+  echo "$yaml" | yq -o=json | jq --arg mirror "$MIRROR" --arg version "$VERSION" --arg arch "$ARCH" '
     [ .[] | select(.iso | test("\\.iso$")) | {
       filename: .iso,
       variant: (.flavor | sub("^alpine-"; "")),
-      url: ($mirror + "/v" + $version + "/releases/x86_64/" + .iso),
+      url: ($mirror + "/v" + $version + "/releases/" + $arch + "/" + .iso),
       sha256: .sha256
     } ]'
 }
@@ -36,7 +39,7 @@ fetch_version_list() {
 }
 
 if [[ -n "$VERSION" ]]; then
-  entries=$(spin "Fetching Alpine $VERSION..." bash -c "$(declare -f fetch_version_detail); VERSION='$VERSION' MIRROR='$MIRROR' fetch_version_detail")
+  entries=$(spin "Fetching Alpine $VERSION ($ARCH)..." bash -c "$(declare -f fetch_version_detail); VERSION='$VERSION' MIRROR='$MIRROR' ARCH='$ARCH' fetch_version_detail")
 
   if [[ "$JSON" == "true" ]]; then
     echo "$entries" | jq .

--- a/.mise/tasks/catalog/debian
+++ b/.mise/tasks/catalog/debian
@@ -13,6 +13,12 @@ source "$MISE_CONFIG_ROOT/lib/common.sh"
 
 ARCH=$(resolve_arch debian "${usage_arch:-}") || { echo "Error: Debian does not publish live ISOs for architecture '${usage_arch:-$(uname -m)}'." >&2; exit 1; }
 
+# Verify this arch has live ISOs on the mirror
+if ! curl -fsSL -o /dev/null "$MIRROR/debian-cd/current-live/$ARCH/iso-hybrid/" 2>/dev/null; then
+  echo "Error: Debian does not publish live ISOs for $ARCH. Try 'amd64' or check https://cdimage.debian.org/debian-cd/current-live/" >&2
+  exit 1
+fi
+
 fetch_version_detail() {
   local base sha_content
 

--- a/.mise/tasks/catalog/debian
+++ b/.mise/tasks/catalog/debian
@@ -13,12 +13,6 @@ source "$MISE_CONFIG_ROOT/lib/common.sh"
 
 ARCH=$(resolve_arch debian "${usage_arch:-}") || { echo "Error: Debian does not publish live ISOs for architecture '${usage_arch:-$(uname -m)}'." >&2; exit 1; }
 
-# Verify this arch has live ISOs on the mirror
-if ! curl -fsSL -o /dev/null "$MIRROR/debian-cd/current-live/$ARCH/iso-hybrid/" 2>/dev/null; then
-  echo "Error: Debian does not publish live ISOs for $ARCH. Try 'amd64' or check https://cdimage.debian.org/debian-cd/current-live/" >&2
-  exit 1
-fi
-
 fetch_version_detail() {
   local base sha_content
 
@@ -32,7 +26,7 @@ fetch_version_detail() {
     base="$MIRROR/cdimage/archive/${VERSION}-live/$ARCH/iso-hybrid"
   fi
 
-  sha_content=$(curl -fsSL "$base/SHA256SUMS" 2>/dev/null) || { echo "Error: version $VERSION not found." >&2; exit 1; }
+  sha_content=$(curl -fsSL "$base/SHA256SUMS" 2>/dev/null) || { echo "Error: Debian $VERSION not found for $ARCH. This distro may not publish ISOs for this architecture." >&2; exit 1; }
 
   echo "$sha_content" | grep '\.iso$' | awk '{print $2 "|" $1}' | while IFS='|' read -r filename sha256; do
     variant=$(echo "$filename" | sed "s/.*${ARCH}-\(.*\)\.iso/\1/")

--- a/.mise/tasks/catalog/debian
+++ b/.mise/tasks/catalog/debian
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Show available Debian Live versions and variants"
 #USAGE flag "-v --version <version>" help="Show variants for a specific version"
+#USAGE flag "--arch <arch>" help="Architecture (default: host)" default=""
 #USAGE flag "--json" help="Output as JSON"
 set -euo pipefail
 
@@ -10,23 +11,25 @@ JSON="${usage_json:-false}"
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 
+ARCH=$(resolve_arch debian "${usage_arch:-}") || { echo "Error: Debian does not publish live ISOs for architecture '${usage_arch:-$(uname -m)}'." >&2; exit 1; }
+
 fetch_version_detail() {
   local base sha_content
 
   # Current release lives at a different path than archived ones
   local current_version
-  current_version=$(curl -fsSL "$MIRROR/debian-cd/current-live/amd64/iso-hybrid/" | sed -n 's/.*debian-live-\([0-9.]*\)-.*/\1/p' | head -1)
+  current_version=$(curl -fsSL "$MIRROR/debian-cd/current-live/$ARCH/iso-hybrid/" | sed -n 's/.*debian-live-\([0-9.]*\)-.*/\1/p' | head -1)
 
   if [[ "$VERSION" == "$current_version" ]]; then
-    base="$MIRROR/debian-cd/current-live/amd64/iso-hybrid"
+    base="$MIRROR/debian-cd/current-live/$ARCH/iso-hybrid"
   else
-    base="$MIRROR/cdimage/archive/${VERSION}-live/amd64/iso-hybrid"
+    base="$MIRROR/cdimage/archive/${VERSION}-live/$ARCH/iso-hybrid"
   fi
 
   sha_content=$(curl -fsSL "$base/SHA256SUMS" 2>/dev/null) || { echo "Error: version $VERSION not found." >&2; exit 1; }
 
   echo "$sha_content" | grep '\.iso$' | awk '{print $2 "|" $1}' | while IFS='|' read -r filename sha256; do
-    variant=$(echo "$filename" | sed 's/.*amd64-\(.*\)\.iso/\1/')
+    variant=$(echo "$filename" | sed "s/.*${ARCH}-\(.*\)\.iso/\1/")
     echo "$filename|$variant|$sha256"
   done | jq -R --arg base "$base" '
     split("|") | {
@@ -41,7 +44,7 @@ fetch_version_list() {
   local current_html current_version archive_html
 
   # Get current version
-  current_html=$(curl -fsSL "$MIRROR/debian-cd/current-live/amd64/iso-hybrid/")
+  current_html=$(curl -fsSL "$MIRROR/debian-cd/current-live/$ARCH/iso-hybrid/")
   current_version=$(echo "$current_html" | sed -n 's/.*debian-live-\([0-9.]*\)-.*/\1/p' | head -1)
 
   # Get archived versions
@@ -56,7 +59,7 @@ fetch_version_list() {
 }
 
 if [[ -n "$VERSION" ]]; then
-  entries=$(spin "Fetching Debian $VERSION..." bash -c "$(declare -f fetch_version_detail); VERSION='$VERSION' MIRROR='$MIRROR' fetch_version_detail")
+  entries=$(spin "Fetching Debian $VERSION ($ARCH)..." bash -c "$(declare -f fetch_version_detail); VERSION='$VERSION' MIRROR='$MIRROR' ARCH='$ARCH' fetch_version_detail")
 
   if [[ "$JSON" == "true" ]]; then
     echo "$entries" | jq .
@@ -67,7 +70,7 @@ if [[ -n "$VERSION" ]]; then
       | tr -d '"' | gum table -p -w 50,15
   fi
 else
-  entries=$(spin "Fetching Debian versions..." bash -c "$(declare -f fetch_version_list); MIRROR='$MIRROR' fetch_version_list")
+  entries=$(spin "Fetching Debian versions..." bash -c "$(declare -f fetch_version_list); MIRROR='$MIRROR' ARCH='$ARCH' fetch_version_list")
 
   if [[ "$JSON" == "true" ]]; then
     echo "$entries" | jq .

--- a/.mise/tasks/catalog/mint
+++ b/.mise/tasks/catalog/mint
@@ -15,7 +15,7 @@ resolve_arch mint "${usage_arch:-}" >/dev/null || { echo "Error: Linux Mint does
 
 fetch_version_detail() {
   local html sha_content parsed
-  html=$(curl -fsSL "$MIRROR/$VERSION/") || { echo "Error: version $VERSION not found." >&2; exit 1; }
+  html=$(curl -fsSL "$MIRROR/$VERSION/") || { echo "Error: Mint $VERSION not found. This distro may not publish ISOs for this version." >&2; exit 1; }
   sha_content=$(curl -fsSL "$MIRROR/$VERSION/sha256sum.txt" 2>/dev/null || echo "")
 
   mapfile -t isos < <(echo "$html" | sed -n 's/.*href="\([^"]*\.iso\)".*/\1/p')

--- a/.mise/tasks/catalog/mint
+++ b/.mise/tasks/catalog/mint
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Show available Linux Mint versions and variants"
 #USAGE flag "-v --version <version>" help="Show variants for a specific version"
+#USAGE flag "--arch <arch>" help="Architecture (default: host)" default=""
 #USAGE flag "--json" help="Output as JSON"
 set -euo pipefail
 
@@ -9,6 +10,8 @@ VERSION="${usage_version:-}"
 JSON="${usage_json:-false}"
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
+
+resolve_arch mint "${usage_arch:-}" >/dev/null || { echo "Error: Linux Mint does not publish ISOs for architecture '${usage_arch:-$(uname -m)}'. Only x86_64 is available." >&2; exit 1; }
 
 fetch_version_detail() {
   local html sha_content parsed

--- a/.mise/tasks/catalog/pop-os
+++ b/.mise/tasks/catalog/pop-os
@@ -24,7 +24,7 @@ fetch_version_detail() {
   channels=$(curl -fsSL "$BUCKET/?list-type=2&delimiter=/&prefix=$VERSION/$ARCH/" | s3_prefixes | grep -v "^$VERSION/$ARCH$" | while read -r p; do basename "$p"; done)
 
   if [[ -z "$channels" ]]; then
-    echo "Error: no channels found for Pop!_OS $VERSION." >&2
+    echo "Error: Pop!_OS $VERSION not found for $ARCH. This distro may not publish ISOs for this architecture." >&2
     exit 1
   fi
 

--- a/.mise/tasks/catalog/pop-os
+++ b/.mise/tasks/catalog/pop-os
@@ -21,7 +21,7 @@ s3_prefixes() {
 
 fetch_version_detail() {
   local channels parsed channel api_resp url sha256 size build
-  channels=$(curl -fsSL "$BUCKET/?list-type=2&delimiter=/&prefix=$VERSION/$ARCH/" | s3_prefixes | grep -v "^$VERSION/amd64$" | while read -r p; do basename "$p"; done)
+  channels=$(curl -fsSL "$BUCKET/?list-type=2&delimiter=/&prefix=$VERSION/$ARCH/" | s3_prefixes | grep -v "^$VERSION/$ARCH$" | while read -r p; do basename "$p"; done)
 
   if [[ -z "$channels" ]]; then
     echo "Error: no channels found for Pop!_OS $VERSION." >&2

--- a/.mise/tasks/catalog/pop-os
+++ b/.mise/tasks/catalog/pop-os
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #MISE description="Show available Pop!_OS versions and variants"
 #USAGE flag "-v --version <version>" help="Show variants for a specific version"
+#USAGE flag "--arch <arch>" help="Architecture (default: host)" default=""
 #USAGE flag "--json" help="Output as JSON"
 set -euo pipefail
 
@@ -11,6 +12,8 @@ JSON="${usage_json:-false}"
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 
+ARCH=$(resolve_arch pop-os "${usage_arch:-}") || { echo "Error: Pop!_OS does not publish ISOs for architecture '${usage_arch:-$(uname -m)}'. Only x86_64/amd64 is available." >&2; exit 1; }
+
 # Parse S3 CommonPrefixes from XML (may be single-line)
 s3_prefixes() {
   tr '<' '\n' | sed -n 's|^Prefix>\([^<]*\).*|\1|p' | sed 's|/$||'
@@ -18,7 +21,7 @@ s3_prefixes() {
 
 fetch_version_detail() {
   local channels parsed channel api_resp url sha256 size build
-  channels=$(curl -fsSL "$BUCKET/?list-type=2&delimiter=/&prefix=$VERSION/amd64/" | s3_prefixes | grep -v "^$VERSION/amd64$" | while read -r p; do basename "$p"; done)
+  channels=$(curl -fsSL "$BUCKET/?list-type=2&delimiter=/&prefix=$VERSION/$ARCH/" | s3_prefixes | grep -v "^$VERSION/amd64$" | while read -r p; do basename "$p"; done)
 
   if [[ -z "$channels" ]]; then
     echo "Error: no channels found for Pop!_OS $VERSION." >&2
@@ -27,7 +30,7 @@ fetch_version_detail() {
 
   parsed=""
   for channel in $channels; do
-    api_resp=$(curl -fsSL "$API/$VERSION/$channel?arch=amd64" 2>/dev/null || echo "")
+    api_resp=$(curl -fsSL "$API/$VERSION/$channel?arch=$ARCH" 2>/dev/null || echo "")
     url="" sha256="" size="0" build="unknown"
     if [[ -n "$api_resp" ]] && echo "$api_resp" | grep -q '"url"'; then
       url=$(echo "$api_resp" | jq -r '.url // ""')
@@ -38,9 +41,9 @@ fetch_version_detail() {
     parsed+="${channel}|${build}|${size}|${url}|${sha256}"$'\n'
   done
 
-  echo -n "$parsed" | jq -R --arg version "$VERSION" '
+  echo -n "$parsed" | jq -R --arg version "$VERSION" --arg arch "$ARCH" '
     split("|") | {
-      filename: ("pop-os_" + $version + "_amd64_" + .[0] + "_" + .[1] + ".iso"),
+      filename: ("pop-os_" + $version + "_" + $arch + "_" + .[0] + "_" + .[1] + ".iso"),
       channel: .[0],
       build: .[1],
       size: (.[2] | tonumber),
@@ -56,7 +59,7 @@ fetch_version_list() {
 
   parsed=""
   for ver in $versions; do
-    channels=$(curl -fsSL "$BUCKET/?list-type=2&delimiter=/&prefix=$ver/amd64/" 2>/dev/null | s3_prefixes | grep -v "^$ver/amd64$" | while read -r p; do basename "$p"; done | paste -sd ',' -)
+    channels=$(curl -fsSL "$BUCKET/?list-type=2&delimiter=/&prefix=$ver/$ARCH/" 2>/dev/null | s3_prefixes | grep -v "^$ver/$ARCH$" | while read -r p; do basename "$p"; done | paste -sd ',' -)
     parsed+="${ver}|${channels}"$'\n'
   done
 
@@ -68,7 +71,7 @@ fetch_version_list() {
 }
 
 if [[ -n "$VERSION" ]]; then
-  entries=$(spin "Fetching Pop!_OS $VERSION..." bash -c "$(declare -f s3_prefixes fetch_version_detail); VERSION='$VERSION' BUCKET='$BUCKET' API='$API' fetch_version_detail")
+  entries=$(spin "Fetching Pop!_OS $VERSION ($ARCH)..." bash -c "$(declare -f s3_prefixes fetch_version_detail); VERSION='$VERSION' BUCKET='$BUCKET' API='$API' ARCH='$ARCH' fetch_version_detail")
 
   if [[ "$JSON" == "true" ]]; then
     echo "$entries" | jq .
@@ -79,7 +82,7 @@ if [[ -n "$VERSION" ]]; then
       | tr -d '"' | gum table -p -w 12,8,10
   fi
 else
-  entries=$(spin "Fetching Pop!_OS versions..." bash -c "$(declare -f s3_prefixes fetch_version_list); BUCKET='$BUCKET' fetch_version_list")
+  entries=$(spin "Fetching Pop!_OS versions..." bash -c "$(declare -f s3_prefixes fetch_version_list); BUCKET='$BUCKET' ARCH='$ARCH' fetch_version_list")
 
   if [[ "$JSON" == "true" ]]; then
     echo "$entries" | jq .

--- a/.mise/tasks/iso/get
+++ b/.mise/tasks/iso/get
@@ -2,12 +2,14 @@
 #MISE description="Download and verify an ISO from the catalog"
 #USAGE arg "<distro>" help="Distribution name (mint, pop-os)"
 #USAGE flag "-v --version <version>" help="Version to download"
+#USAGE flag "--arch <arch>" help="Architecture (default: host)" default=""
 #USAGE flag "--variant <variant>" help="Variant/channel to download"
 #USAGE flag "--force" help="Re-download even if already present"
 set -euo pipefail
 
 DISTRO="$usage_distro"
 VERSION="${usage_version:-}"
+ARCH_FLAG="${usage_arch:-}"
 VARIANT="${usage_variant:-}"
 FORCE="${usage_force:-false}"
 ISO_DIR="${WINNIE_ISO_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/winnie/isos}"
@@ -30,7 +32,8 @@ esac
 # --- resolve version (interactive if not specified) ---
 
 if [[ -z "$VERSION" ]]; then
-  versions_json=$(spin "Fetching $DISTRO versions..." mise run -q "catalog:$DISTRO" -- --json)
+  arch_args=(); [[ -n "$ARCH_FLAG" ]] && arch_args=(--arch "$ARCH_FLAG")
+  versions_json=$(spin "Fetching $DISTRO versions..." mise run -q "catalog:$DISTRO" -- --json "${arch_args[@]}")
   versions=$(echo "$versions_json" | jq -r '.[].version')
 
   [[ -z "$versions" ]] && die "no versions found for $DISTRO"
@@ -44,7 +47,8 @@ fi
 
 # --- fetch ISO details for the chosen version ---
 
-detail_json=$(spin "Fetching $DISTRO $VERSION details..." mise run -q "catalog:$DISTRO" -- --version "$VERSION" --json)
+arch_args=(); [[ -n "$ARCH_FLAG" ]] && arch_args=(--arch "$ARCH_FLAG")
+detail_json=$(spin "Fetching $DISTRO $VERSION details..." mise run -q "catalog:$DISTRO" -- --version "$VERSION" --json "${arch_args[@]}")
 
 [[ -z "$detail_json" || "$detail_json" == "[]" ]] && die "no ISOs found for $DISTRO $VERSION"
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -10,3 +10,45 @@ spin() {
     "$@"
   fi
 }
+
+# Map host architecture to distro-specific arch string.
+# Usage: resolve_arch <distro> [arch]
+# If arch is omitted, detects from uname -m.
+# Returns empty string (and exits 1) if the distro doesn't support the arch.
+resolve_arch() {
+  local distro="$1"
+  local raw="${2:-$(uname -m)}"
+
+  # Normalize: macOS says "arm64", Linux says "aarch64"
+  case "$raw" in
+    arm64|aarch64) raw="aarch64" ;;
+    x86_64|amd64)  raw="x86_64" ;;
+  esac
+
+  case "$distro" in
+    alpine)
+      case "$raw" in
+        x86_64)  echo "x86_64" ;;
+        aarch64) echo "aarch64" ;;
+        *) return 1 ;;
+      esac ;;
+    debian)
+      case "$raw" in
+        x86_64)  echo "amd64" ;;
+        aarch64) echo "arm64" ;;
+        *) return 1 ;;
+      esac ;;
+    pop-os)
+      case "$raw" in
+        x86_64) echo "amd64" ;;
+        *) return 1 ;;
+      esac ;;
+    mint)
+      case "$raw" in
+        x86_64) echo "64bit" ;;
+        *) return 1 ;;
+      esac ;;
+    *)
+      echo "$raw" ;;
+  esac
+}

--- a/tests/test_resolve_arch.bats
+++ b/tests/test_resolve_arch.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+# Tests for resolve_arch() in lib/common.sh
+
+load test_helper
+
+setup() {
+  source "$MISE_CONFIG_ROOT/lib/common.sh"
+}
+
+# --- alpine ---
+
+@test "resolve_arch alpine x86_64" {
+  run resolve_arch alpine x86_64
+  [ "$status" -eq 0 ]
+  [ "$output" = "x86_64" ]
+}
+
+@test "resolve_arch alpine aarch64" {
+  run resolve_arch alpine aarch64
+  [ "$status" -eq 0 ]
+  [ "$output" = "aarch64" ]
+}
+
+@test "resolve_arch alpine arm64 normalizes to aarch64" {
+  run resolve_arch alpine arm64
+  [ "$status" -eq 0 ]
+  [ "$output" = "aarch64" ]
+}
+
+# --- debian ---
+
+@test "resolve_arch debian x86_64 maps to amd64" {
+  run resolve_arch debian x86_64
+  [ "$status" -eq 0 ]
+  [ "$output" = "amd64" ]
+}
+
+@test "resolve_arch debian amd64 maps to amd64" {
+  run resolve_arch debian amd64
+  [ "$status" -eq 0 ]
+  [ "$output" = "amd64" ]
+}
+
+@test "resolve_arch debian aarch64 maps to arm64" {
+  run resolve_arch debian aarch64
+  [ "$status" -eq 0 ]
+  [ "$output" = "arm64" ]
+}
+
+@test "resolve_arch debian arm64 maps to arm64" {
+  run resolve_arch debian arm64
+  [ "$status" -eq 0 ]
+  [ "$output" = "arm64" ]
+}
+
+# --- pop-os (x86 only) ---
+
+@test "resolve_arch pop-os x86_64 maps to amd64" {
+  run resolve_arch pop-os x86_64
+  [ "$status" -eq 0 ]
+  [ "$output" = "amd64" ]
+}
+
+@test "resolve_arch pop-os aarch64 fails" {
+  run resolve_arch pop-os aarch64
+  [ "$status" -ne 0 ]
+}
+
+# --- mint (x86 only) ---
+
+@test "resolve_arch mint x86_64 maps to 64bit" {
+  run resolve_arch mint x86_64
+  [ "$status" -eq 0 ]
+  [ "$output" = "64bit" ]
+}
+
+@test "resolve_arch mint aarch64 fails" {
+  run resolve_arch mint aarch64
+  [ "$status" -ne 0 ]
+}
+
+# --- defaults to host arch when empty ---
+
+@test "resolve_arch defaults to host when arch is empty" {
+  run resolve_arch alpine ""
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+# --- unknown distro passes through ---
+
+@test "resolve_arch unknown distro passes raw arch through" {
+  run resolve_arch some-future-distro x86_64
+  [ "$status" -eq 0 ]
+  [ "$output" = "x86_64" ]
+}


### PR DESCRIPTION
## Summary

- Add `--arch` flag to all catalog tasks (alpine, debian, pop-os, mint) and `iso:get`, defaulting to host architecture via `uname -m`
- New `resolve_arch()` helper in `lib/common.sh` normalizes arch names (arm64↔aarch64, x86_64↔amd64) to each distro's conventions
- Distros that don't publish ISOs for a given arch (e.g. Pop!_OS on ARM, Mint on ARM) fail early with a clear message
- 13 new tests for `resolve_arch` covering all distro×arch combinations

## Test plan

- [x] 76/76 tests pass (`mise run test`)
- [x] Smoke tested `catalog:debian --arch x86_64` — returns real ISOs
- [x] Smoke tested `catalog:alpine --arch aarch64` — returns real aarch64 ISOs
- [x] Smoke tested `catalog:debian --arch aarch64` — correctly reports unavailable (Debian doesn't publish arm64 live ISOs)

Part of #11 (multi-architecture VM support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)