### PR TITLE
Multi-arch vm:boot

### DIFF
--- a/.mise/tasks/catalog/pop-os
+++ b/.mise/tasks/catalog/pop-os
@@ -12,7 +12,7 @@ JSON="${usage_json:-false}"
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 
-ARCH=$(resolve_arch pop-os "${usage_arch:-}") || { echo "Error: Pop!_OS does not publish ISOs for architecture '${usage_arch:-$(uname -m)}'. Only x86_64/amd64 is available." >&2; exit 1; }
+ARCH=$(resolve_arch pop-os "${usage_arch:-}") || { echo "Error: Pop!_OS does not publish ISOs for architecture '${usage_arch:-$(uname -m)}'." >&2; exit 1; }
 
 # Parse S3 CommonPrefixes from XML (may be single-line)
 s3_prefixes() {

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -21,6 +21,11 @@ if ! check mkisofs; then
   missing+=("mkisofs")
 fi
 
+# socat — needed for vm:screenshot and vm:list (Unix domain socket communication)
+if ! check socat; then
+  missing+=("socat")
+fi
+
 # grub-install — needed for format task (Linux only)
 if [[ "$(uname)" == "Linux" ]]; then
   if ! check grub-install && ! check grub2-install; then
@@ -63,6 +68,7 @@ install_brew() {
     case "$dep" in
       qemu)    pkgs+=("qemu") ;;
       mkisofs) pkgs+=("cdrtools") ;;
+      socat)   pkgs+=("socat") ;;
     esac
   done
   [[ ${#pkgs[@]} -gt 0 ]] && brew install "${pkgs[@]}"
@@ -74,6 +80,7 @@ install_apt() {
     case "$dep" in
       qemu)    pkgs+=("qemu-system-x86") ;;
       mkisofs) pkgs+=("genisoimage") ;;
+      socat)   pkgs+=("socat") ;;
       grub)    pkgs+=("grub-pc-bin" "grub-efi-amd64-bin" "grub2-common") ;;
       sgdisk)  pkgs+=("gdisk") ;;
       mkfs)    pkgs+=("dosfstools" "e2fsprogs") ;;
@@ -88,6 +95,7 @@ install_dnf() {
     case "$dep" in
       qemu)    pkgs+=("qemu-system-x86") ;;
       mkisofs) pkgs+=("genisoimage") ;;
+      socat)   pkgs+=("socat") ;;
       grub)    pkgs+=("grub2-pc-modules" "grub2-efi-x64-modules" "grub2-tools") ;;
       sgdisk)  pkgs+=("gdisk") ;;
       mkfs)    pkgs+=("dosfstools" "e2fsprogs") ;;
@@ -102,6 +110,7 @@ install_pacman() {
     case "$dep" in
       qemu)    pkgs+=("qemu-system-x86") ;;
       mkisofs) pkgs+=("cdrtools") ;;
+      socat)   pkgs+=("socat") ;;
       grub)    pkgs+=("grub") ;;
       sgdisk)  pkgs+=("gptfdisk") ;;
       mkfs)    pkgs+=("dosfstools" "e2fsprogs") ;;

--- a/.mise/tasks/setup
+++ b/.mise/tasks/setup
@@ -12,18 +12,18 @@ check() {
 missing=()
 
 # QEMU — needed for VM testing
-if ! check qemu-system-x86_64; then
+if ! check qemu-system-x86_64 || ! check qemu-system-aarch64; then
   missing+=("qemu")
+fi
+
+# socat — needed for QEMU monitor socket communication (vm:screenshot, vm:list)
+if ! check socat; then
+  missing+=("socat")
 fi
 
 # mkisofs — needed for creating mock ISOs in tests
 if ! check mkisofs; then
   missing+=("mkisofs")
-fi
-
-# socat — needed for vm:screenshot and vm:list (Unix domain socket communication)
-if ! check socat; then
-  missing+=("socat")
 fi
 
 # grub-install — needed for format task (Linux only)
@@ -66,8 +66,8 @@ install_brew() {
   local pkgs=()
   for dep in "${missing[@]}"; do
     case "$dep" in
-      qemu)    pkgs+=("qemu") ;;
       mkisofs) pkgs+=("cdrtools") ;;
+      qemu)    pkgs+=("qemu") ;;
       socat)   pkgs+=("socat") ;;
     esac
   done
@@ -78,12 +78,12 @@ install_apt() {
   local pkgs=()
   for dep in "${missing[@]}"; do
     case "$dep" in
-      qemu)    pkgs+=("qemu-system-x86") ;;
-      mkisofs) pkgs+=("genisoimage") ;;
-      socat)   pkgs+=("socat") ;;
       grub)    pkgs+=("grub-pc-bin" "grub-efi-amd64-bin" "grub2-common") ;;
-      sgdisk)  pkgs+=("gdisk") ;;
       mkfs)    pkgs+=("dosfstools" "e2fsprogs") ;;
+      mkisofs) pkgs+=("genisoimage") ;;
+      qemu)    pkgs+=("qemu-system-x86" "qemu-system-arm") ;;
+      sgdisk)  pkgs+=("gdisk") ;;
+      socat)   pkgs+=("socat") ;;
     esac
   done
   [[ ${#pkgs[@]} -gt 0 ]] && sudo apt-get update && sudo apt-get install -y "${pkgs[@]}"
@@ -93,12 +93,12 @@ install_dnf() {
   local pkgs=()
   for dep in "${missing[@]}"; do
     case "$dep" in
-      qemu)    pkgs+=("qemu-system-x86") ;;
-      mkisofs) pkgs+=("genisoimage") ;;
-      socat)   pkgs+=("socat") ;;
       grub)    pkgs+=("grub2-pc-modules" "grub2-efi-x64-modules" "grub2-tools") ;;
-      sgdisk)  pkgs+=("gdisk") ;;
       mkfs)    pkgs+=("dosfstools" "e2fsprogs") ;;
+      mkisofs) pkgs+=("genisoimage") ;;
+      qemu)    pkgs+=("qemu-system-x86" "qemu-system-aarch64") ;;
+      sgdisk)  pkgs+=("gdisk") ;;
+      socat)   pkgs+=("socat") ;;
     esac
   done
   [[ ${#pkgs[@]} -gt 0 ]] && sudo dnf install -y "${pkgs[@]}"
@@ -108,12 +108,12 @@ install_pacman() {
   local pkgs=()
   for dep in "${missing[@]}"; do
     case "$dep" in
-      qemu)    pkgs+=("qemu-system-x86") ;;
-      mkisofs) pkgs+=("cdrtools") ;;
-      socat)   pkgs+=("socat") ;;
       grub)    pkgs+=("grub") ;;
-      sgdisk)  pkgs+=("gptfdisk") ;;
       mkfs)    pkgs+=("dosfstools" "e2fsprogs") ;;
+      mkisofs) pkgs+=("cdrtools") ;;
+      qemu)    pkgs+=("qemu-system-x86") ;;
+      sgdisk)  pkgs+=("gptfdisk") ;;
+      socat)   pkgs+=("socat") ;;
     esac
   done
   [[ ${#pkgs[@]} -gt 0 ]] && sudo pacman -S --noconfirm "${pkgs[@]}"

--- a/.mise/tasks/vm/boot
+++ b/.mise/tasks/vm/boot
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Boot a winnie disk image in QEMU"
-#USAGE flag "-i --image <path>" help="Disk image path" default="disk.img"
+#USAGE flag "-i --image <path>" help="Disk image path" default=""
 #USAGE flag "--arch <arch>" help="Guest architecture (default: host)" default=""
 #USAGE flag "--uefi" help="Boot in UEFI mode (default: BIOS)"
 #USAGE flag "--headless" help="Headless mode (serial console, no GUI window)"
@@ -12,7 +12,7 @@ set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 
-IMAGE="${usage_image}"
+IMAGE="${usage_image:-}"
 CDROM="${usage_cdrom:-}"
 UEFI="${usage_uefi:-false}"
 HEADLESS="${usage_headless:-false}"
@@ -20,11 +20,9 @@ MEMORY="${usage_memory}"
 CPUS="${usage_cpus}"
 NO_NET="${usage_no_net:-false}"
 
-# Need at least a disk image or a cdrom
-if [[ -z "$CDROM" && ! -f "$IMAGE" ]]; then
+if [[ -n "$IMAGE" && ! -f "$IMAGE" ]]; then
   echo "Error: $IMAGE not found."
   echo "Create one with: winnie disk:format --image disk.img"
-  echo "Or boot an ISO directly with: winnie vm:boot --cdrom <iso>"
   exit 1
 fi
 
@@ -67,14 +65,11 @@ QEMU_ARGS=(
 [[ -n "$CPU" ]] && QEMU_ARGS+=(-cpu "$CPU")
 
 # Disk and/or cdrom
+[[ -n "$IMAGE" ]] && QEMU_ARGS+=(-drive "file=$IMAGE,format=raw,if=virtio")
 if [[ -n "$CDROM" ]]; then
   QEMU_ARGS+=(-cdrom "$CDROM" -boot d)
-  # Also attach disk image if it exists (for installing to disk from ISO)
-  if [[ -f "$IMAGE" ]]; then
-    QEMU_ARGS+=(-drive "file=$IMAGE,format=raw,if=virtio")
-  fi
-else
-  QEMU_ARGS+=(-drive "file=$IMAGE,format=raw,if=virtio" -boot c)
+elif [[ -n "$IMAGE" ]]; then
+  QEMU_ARGS+=(-boot c)
 fi
 
 # Network: user-mode NAT by default (guest gets internet, host can't reach guest)
@@ -161,8 +156,10 @@ fi
 # Named by image basename so multiple VMs can run concurrently.
 if [[ -n "$CDROM" ]]; then
   VM_ID="$(basename "$CDROM" .iso)"
-else
+elif [[ -n "$IMAGE" ]]; then
   VM_ID="$(basename "$IMAGE" .img)"
+else
+  VM_ID="winnie-$$"
 fi
 WINNIE_RUN_DIR="${TMPDIR:-/tmp}/winnie"
 mkdir -p "$WINNIE_RUN_DIR"
@@ -180,7 +177,8 @@ fi
 ACCEL_LABEL="$ACCEL"
 [[ "$NATIVE" == "true" ]] && ACCEL_LABEL="$ACCEL (native)"
 
-BOOT_SOURCE="$IMAGE"
+BOOT_SOURCE="(no disk)"
+[[ -n "$IMAGE" ]] && BOOT_SOURCE="$IMAGE"
 [[ -n "$CDROM" ]] && BOOT_SOURCE="$CDROM (cdrom)"
 
 BOOT_MODE="BIOS"

--- a/.mise/tasks/vm/boot
+++ b/.mise/tasks/vm/boot
@@ -64,12 +64,15 @@ QEMU_ARGS=(
 [[ -n "$MACHINE" ]] && QEMU_ARGS+=(-machine "$MACHINE")
 [[ -n "$CPU" ]] && QEMU_ARGS+=(-cpu "$CPU")
 
-# aarch64's -machine virt has no default display device (unlike x86 which
-# includes a VGA). Without one, graphical desktops can't start and
-# vm:screenshot has no framebuffer to capture. virtio-gpu-pci is the
-# standard paravirtualized GPU for Linux guests.
+# aarch64's -machine virt has no default display, input, or USB devices
+# (unlike x86 which includes VGA + PS/2). Add them explicitly.
 if [[ "$GUEST_ARCH" == "aarch64" ]]; then
-  QEMU_ARGS+=(-device virtio-gpu-pci)
+  QEMU_ARGS+=(
+    -device virtio-gpu-pci
+    -device qemu-xhci
+    -device usb-kbd
+    -device usb-tablet
+  )
 fi
 
 # Disk and/or cdrom

--- a/.mise/tasks/vm/boot
+++ b/.mise/tasks/vm/boot
@@ -6,21 +6,30 @@
 #USAGE flag "--headless" help="Headless mode (serial console, no GUI window)"
 #USAGE flag "-m --memory <size>" help="RAM in MB" default="512"
 #USAGE flag "--cpus <n>" help="Number of CPU cores" default="2"
+#USAGE flag "--cdrom <path>" help="Boot from ISO file instead of disk image"
 #USAGE flag "--no-net" help="Disable network (default: user-mode NAT)"
 set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 
 IMAGE="${usage_image}"
+CDROM="${usage_cdrom:-}"
 UEFI="${usage_uefi:-false}"
 HEADLESS="${usage_headless:-false}"
 MEMORY="${usage_memory}"
 CPUS="${usage_cpus}"
 NO_NET="${usage_no_net:-false}"
 
-if [[ ! -f "$IMAGE" ]]; then
+# Need at least a disk image or a cdrom
+if [[ -z "$CDROM" && ! -f "$IMAGE" ]]; then
   echo "Error: $IMAGE not found."
   echo "Create one with: winnie disk:format --image disk.img"
+  echo "Or boot an ISO directly with: winnie vm:boot --cdrom <iso>"
+  exit 1
+fi
+
+if [[ -n "$CDROM" && ! -f "$CDROM" ]]; then
+  echo "Error: $CDROM not found."
   exit 1
 fi
 
@@ -57,10 +66,16 @@ QEMU_ARGS=(
 [[ -n "$MACHINE" ]] && QEMU_ARGS+=(-machine "$MACHINE")
 [[ -n "$CPU" ]] && QEMU_ARGS+=(-cpu "$CPU")
 
-QEMU_ARGS+=(
-  -drive "file=$IMAGE,format=raw,if=virtio"
-  -boot c
-)
+# Disk and/or cdrom
+if [[ -n "$CDROM" ]]; then
+  QEMU_ARGS+=(-cdrom "$CDROM" -boot d)
+  # Also attach disk image if it exists (for installing to disk from ISO)
+  if [[ -f "$IMAGE" ]]; then
+    QEMU_ARGS+=(-drive "file=$IMAGE,format=raw,if=virtio")
+  fi
+else
+  QEMU_ARGS+=(-drive "file=$IMAGE,format=raw,if=virtio" -boot c)
+fi
 
 # Network: user-mode NAT by default (guest gets internet, host can't reach guest)
 if [[ "$NO_NET" != "true" ]]; then
@@ -144,7 +159,11 @@ fi
 
 # --- QEMU monitor socket ---
 # Named by image basename so multiple VMs can run concurrently.
-VM_ID="$(basename "$IMAGE" .img)"
+if [[ -n "$CDROM" ]]; then
+  VM_ID="$(basename "$CDROM" .iso)"
+else
+  VM_ID="$(basename "$IMAGE" .img)"
+fi
 WINNIE_RUN_DIR="${TMPDIR:-/tmp}/winnie"
 mkdir -p "$WINNIE_RUN_DIR"
 MONITOR_SOCK="$WINNIE_RUN_DIR/$VM_ID.sock"
@@ -161,5 +180,17 @@ fi
 ACCEL_LABEL="$ACCEL"
 [[ "$NATIVE" == "true" ]] && ACCEL_LABEL="$ACCEL (native)"
 
-echo "Booting $IMAGE ($GUEST_ARCH, $(if [[ "$UEFI" == "true" ]]; then echo "UEFI"; else echo "BIOS"; fi), ${MEMORY}MB RAM, ${CPUS} CPUs, $ACCEL_LABEL$(if [[ "$HEADLESS" == "true" ]]; then echo ", headless"; fi)$(if [[ "$NO_NET" == "true" ]]; then echo ", no network"; else echo ", NAT network"; fi))..."
+BOOT_SOURCE="$IMAGE"
+[[ -n "$CDROM" ]] && BOOT_SOURCE="$CDROM (cdrom)"
+
+BOOT_MODE="BIOS"
+[[ "$UEFI" == "true" ]] && BOOT_MODE="UEFI"
+
+NET_MODE="NAT network"
+[[ "$NO_NET" == "true" ]] && NET_MODE="no network"
+
+OPTS="$GUEST_ARCH, $BOOT_MODE, ${MEMORY}MB RAM, ${CPUS} CPUs, $ACCEL_LABEL, $NET_MODE"
+[[ "$HEADLESS" == "true" ]] && OPTS="$OPTS, headless"
+
+echo "Booting $BOOT_SOURCE ($OPTS)..."
 exec "${QEMU_ARGS[@]}"

--- a/.mise/tasks/vm/boot
+++ b/.mise/tasks/vm/boot
@@ -70,7 +70,8 @@ fi
 # --- UEFI firmware ---
 
 if [[ "$UEFI" == "true" ]]; then
-  BREW_PREFIX="$(brew --prefix 2>/dev/null || echo "")"
+  BREW_PREFIX=""
+  [[ "$(uname -s)" == "Darwin" ]] && BREW_PREFIX="$(brew --prefix 2>/dev/null || echo "")"
 
   # Firmware paths differ by arch
   FW_CODE=""
@@ -87,7 +88,15 @@ if [[ "$UEFI" == "true" ]]; then
           break
         fi
       done
-      FW_VARS="${FW_CODE:+$(dirname "$FW_CODE")/edk2-i386-vars.fd}"
+      for vars_candidate in \
+        "$BREW_PREFIX/share/qemu/edk2-i386-vars.fd" \
+        /usr/share/OVMF/OVMF_VARS.fd \
+        /usr/share/edk2/x64/OVMF_VARS.fd; do
+        if [[ -f "$vars_candidate" ]]; then
+          FW_VARS="$vars_candidate"
+          break
+        fi
+      done
       ;;
     aarch64)
       for candidate in \
@@ -100,7 +109,15 @@ if [[ "$UEFI" == "true" ]]; then
           break
         fi
       done
-      FW_VARS="${FW_CODE:+$(dirname "$FW_CODE")/edk2-arm-vars.fd}"
+      for vars_candidate in \
+        "$BREW_PREFIX/share/qemu/edk2-arm-vars.fd" \
+        /usr/share/AAVMF/AAVMF_VARS.fd \
+        /usr/share/edk2/aarch64/QEMU_VARS.fd; do
+        if [[ -f "$vars_candidate" ]]; then
+          FW_VARS="$vars_candidate"
+          break
+        fi
+      done
       ;;
   esac
 
@@ -117,7 +134,7 @@ if [[ "$UEFI" == "true" ]]; then
     cp "$FW_VARS" "$VARS_TMP"
   else
     # Create empty 64MB vars file if template not found
-    dd if=/dev/zero of="$VARS_TMP" bs=1m count=64 2>/dev/null
+    truncate -s 64M "$VARS_TMP"
   fi
   QEMU_ARGS+=(
     -drive "if=pflash,format=raw,readonly=on,file=$FW_CODE"

--- a/.mise/tasks/vm/boot
+++ b/.mise/tasks/vm/boot
@@ -64,6 +64,14 @@ QEMU_ARGS=(
 [[ -n "$MACHINE" ]] && QEMU_ARGS+=(-machine "$MACHINE")
 [[ -n "$CPU" ]] && QEMU_ARGS+=(-cpu "$CPU")
 
+# aarch64's -machine virt has no default display device (unlike x86 which
+# includes a VGA). Without one, graphical desktops can't start and
+# vm:screenshot has no framebuffer to capture. virtio-gpu-pci is the
+# standard paravirtualized GPU for Linux guests.
+if [[ "$GUEST_ARCH" == "aarch64" ]]; then
+  QEMU_ARGS+=(-device virtio-gpu-pci)
+fi
+
 # Disk and/or cdrom
 [[ -n "$IMAGE" ]] && QEMU_ARGS+=(-drive "file=$IMAGE,format=raw,if=virtio")
 if [[ -n "$CDROM" ]]; then

--- a/.mise/tasks/vm/boot
+++ b/.mise/tasks/vm/boot
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 #MISE description="Boot a winnie disk image in QEMU"
 #USAGE flag "-i --image <path>" help="Disk image path" default="disk.img"
+#USAGE flag "--arch <arch>" help="Guest architecture (default: host)" default=""
 #USAGE flag "--uefi" help="Boot in UEFI mode (default: BIOS)"
 #USAGE flag "--headless" help="Headless mode (serial console, no GUI window)"
 #USAGE flag "-m --memory <size>" help="RAM in MB" default="512"
 #USAGE flag "--cpus <n>" help="Number of CPU cores" default="2"
 #USAGE flag "--no-net" help="Disable network (default: user-mode NAT)"
 set -euo pipefail
+
+source "$MISE_CONFIG_ROOT/lib/common.sh"
 
 IMAGE="${usage_image}"
 UEFI="${usage_uefi:-false}"
@@ -21,17 +24,40 @@ if [[ ! -f "$IMAGE" ]]; then
   exit 1
 fi
 
-if ! command -v qemu-system-x86_64 &>/dev/null; then
-  echo "Error: qemu-system-x86_64 not found."
+# --- architecture detection ---
+
+HOST_ARCH="$(normalize_arch "$(uname -m)")"
+GUEST_ARCH="$(normalize_arch "${usage_arch:-$HOST_ARCH}")"
+QEMU_BIN="qemu-system-$GUEST_ARCH"
+
+if ! command -v "$QEMU_BIN" &>/dev/null; then
+  echo "Error: $QEMU_BIN not found."
   echo "Install with: winnie setup"
   exit 1
 fi
 
+# --- acceleration ---
+
+ACCEL="$(resolve_accel "$HOST_ARCH" "$GUEST_ARCH" "$(uname -s)")"
+NATIVE=false
+[[ "$ACCEL" != "tcg,thread=multi" ]] && NATIVE=true
+
+# --- build QEMU command ---
+
+MACHINE="$(resolve_machine "$GUEST_ARCH")"
+CPU="$(resolve_cpu "$GUEST_ARCH" "$ACCEL")"
+
 QEMU_ARGS=(
-  qemu-system-x86_64
+  "$QEMU_BIN"
   -m "$MEMORY"
   -smp "$CPUS"
-  -accel tcg,thread=multi
+  -accel "$ACCEL"
+)
+
+[[ -n "$MACHINE" ]] && QEMU_ARGS+=(-machine "$MACHINE")
+[[ -n "$CPU" ]] && QEMU_ARGS+=(-cpu "$CPU")
+
+QEMU_ARGS+=(
   -drive "file=$IMAGE,format=raw,if=virtio"
   -boot c
 )
@@ -41,39 +67,66 @@ if [[ "$NO_NET" != "true" ]]; then
   QEMU_ARGS+=(-nic user,model=virtio-net-pci)
 fi
 
-# UEFI firmware
+# --- UEFI firmware ---
+
 if [[ "$UEFI" == "true" ]]; then
-  # Find OVMF firmware
-  OVMF=""
-  for candidate in \
-    "$(brew --prefix 2>/dev/null)/share/qemu/edk2-x86_64-code.fd" \
-    /usr/share/OVMF/OVMF_CODE.fd \
-    /usr/share/edk2/x64/OVMF_CODE.fd \
-    /usr/share/qemu/OVMF.fd; do
-    if [[ -f "$candidate" ]]; then
-      OVMF="$candidate"
-      break
-    fi
-  done
-  if [[ -z "$OVMF" ]]; then
-    echo "Error: UEFI firmware (OVMF) not found."
+  BREW_PREFIX="$(brew --prefix 2>/dev/null || echo "")"
+
+  # Firmware paths differ by arch
+  FW_CODE=""
+  FW_VARS=""
+  case "$GUEST_ARCH" in
+    x86_64)
+      for candidate in \
+        "$BREW_PREFIX/share/qemu/edk2-x86_64-code.fd" \
+        /usr/share/OVMF/OVMF_CODE.fd \
+        /usr/share/edk2/x64/OVMF_CODE.fd \
+        /usr/share/qemu/OVMF.fd; do
+        if [[ -f "$candidate" ]]; then
+          FW_CODE="$candidate"
+          break
+        fi
+      done
+      FW_VARS="${FW_CODE:+$(dirname "$FW_CODE")/edk2-i386-vars.fd}"
+      ;;
+    aarch64)
+      for candidate in \
+        "$BREW_PREFIX/share/qemu/edk2-aarch64-code.fd" \
+        /usr/share/AAVMF/AAVMF_CODE.fd \
+        /usr/share/edk2/aarch64/QEMU_EFI.fd \
+        /usr/share/qemu/edk2-aarch64-code.fd; do
+        if [[ -f "$candidate" ]]; then
+          FW_CODE="$candidate"
+          break
+        fi
+      done
+      FW_VARS="${FW_CODE:+$(dirname "$FW_CODE")/edk2-arm-vars.fd}"
+      ;;
+  esac
+
+  if [[ -z "$FW_CODE" ]]; then
+    echo "Error: UEFI firmware not found for $GUEST_ARCH."
     echo "It should ship with QEMU. Check your installation."
     exit 1
   fi
+
   # edk2 firmware needs pflash, not -bios
   # Create a temporary writable copy for UEFI vars
-  OVMF_VARS="$(dirname "$OVMF")/edk2-i386-vars.fd"
   VARS_TMP=$(mktemp)
-  cp "$OVMF_VARS" "$VARS_TMP"
+  if [[ -f "$FW_VARS" ]]; then
+    cp "$FW_VARS" "$VARS_TMP"
+  else
+    # Create empty 64MB vars file if template not found
+    dd if=/dev/zero of="$VARS_TMP" bs=1m count=64 2>/dev/null
+  fi
   QEMU_ARGS+=(
-    -drive "if=pflash,format=raw,readonly=on,file=$OVMF"
+    -drive "if=pflash,format=raw,readonly=on,file=$FW_CODE"
     -drive "if=pflash,format=raw,file=$VARS_TMP"
   )
 fi
 
-# QEMU monitor socket — enables vm:screenshot and other monitor commands
+# --- QEMU monitor socket ---
 # Named by image basename so multiple VMs can run concurrently.
-# Use TMPDIR on macOS (per-user, system-managed), fall back to /tmp.
 VM_ID="$(basename "$IMAGE" .img)"
 WINNIE_RUN_DIR="${TMPDIR:-/tmp}/winnie"
 mkdir -p "$WINNIE_RUN_DIR"
@@ -86,5 +139,10 @@ if [[ "$HEADLESS" == "true" ]]; then
   QEMU_ARGS+=(-nographic -serial mon:stdio)
 fi
 
-echo "Booting $IMAGE ($(if [[ "$UEFI" == "true" ]]; then echo "UEFI"; else echo "BIOS"; fi), ${MEMORY}MB RAM, ${CPUS} CPUs$(if [[ "$HEADLESS" == "true" ]]; then echo ", headless"; fi)$(if [[ "$NO_NET" == "true" ]]; then echo ", no network"; else echo ", NAT network"; fi))..."
+# --- boot ---
+
+ACCEL_LABEL="$ACCEL"
+[[ "$NATIVE" == "true" ]] && ACCEL_LABEL="$ACCEL (native)"
+
+echo "Booting $IMAGE ($GUEST_ARCH, $(if [[ "$UEFI" == "true" ]]; then echo "UEFI"; else echo "BIOS"; fi), ${MEMORY}MB RAM, ${CPUS} CPUs, $ACCEL_LABEL$(if [[ "$HEADLESS" == "true" ]]; then echo ", headless"; fi)$(if [[ "$NO_NET" == "true" ]]; then echo ", no network"; else echo ", NAT network"; fi))..."
 exec "${QEMU_ARGS[@]}"

--- a/.mise/tasks/vm/list
+++ b/.mise/tasks/vm/list
@@ -10,11 +10,12 @@ if [[ ! -d "$WINNIE_RUN_DIR" ]]; then
 fi
 
 found=false
+shopt -s nullglob
 for sock in "$WINNIE_RUN_DIR"/*.sock; do
   [[ -S "$sock" ]] || continue
   vm_id="$(basename "$sock" .sock)"
   # Check if the socket is actually connected to a live QEMU process
-  if printf '' | nc -U "$sock" >/dev/null 2>&1; then
+  if printf '' | socat - UNIX-CONNECT:"$sock" >/dev/null 2>&1; then
     echo "$vm_id"
     found=true
   else

--- a/.mise/tasks/vm/list
+++ b/.mise/tasks/vm/list
@@ -15,7 +15,7 @@ for sock in "$WINNIE_RUN_DIR"/*.sock; do
   [[ -S "$sock" ]] || continue
   vm_id="$(basename "$sock" .sock)"
   # Check if the socket is actually connected to a live QEMU process
-  if printf '' | socat - UNIX-CONNECT:"$sock" >/dev/null 2>&1; then
+  if printf '' | socat - "UNIX-CONNECT:$sock" >/dev/null 2>&1; then
     echo "$vm_id"
     found=true
   else

--- a/.mise/tasks/vm/screenshot
+++ b/.mise/tasks/vm/screenshot
@@ -11,11 +11,13 @@ WINNIE_RUN_DIR="${TMPDIR:-/tmp}/winnie"
 
 # If no VM specified, try to find exactly one running VM
 if [[ -z "$VM_NAME" ]]; then
+  shopt -s nullglob
   socks=("$WINNIE_RUN_DIR"/*.sock)
+  shopt -u nullglob
   live=()
   for sock in "${socks[@]}"; do
     [[ -S "$sock" ]] || continue
-    if printf '' | nc -U "$sock" >/dev/null 2>&1; then
+    if printf '' | socat - UNIX-CONNECT:"$sock" >/dev/null 2>&1; then
       live+=("$(basename "$sock" .sock)")
     fi
   done
@@ -47,7 +49,7 @@ fi
 OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
 
 # QEMU screendump supports PNG natively (Homebrew QEMU includes libpng)
-printf 'screendump %s -f png\n' "$OUTPUT" | nc -U "$MONITOR_SOCK" >/dev/null 2>&1
+printf 'screendump %s -f png\n' "$OUTPUT" | socat - UNIX-CONNECT:"$MONITOR_SOCK" >/dev/null 2>&1
 sleep 0.5
 
 if [[ ! -s "$OUTPUT" ]]; then

--- a/.mise/tasks/vm/screenshot
+++ b/.mise/tasks/vm/screenshot
@@ -1,14 +1,40 @@
 #!/usr/bin/env bash
 #MISE description="Capture a screenshot from a running winnie VM"
-#USAGE flag "-i --image <path>" help="Disk image path (identifies which VM)" default="disk.img"
+#USAGE flag "--vm <name>" help="VM identifier (image or ISO filename, or name from vm:list)"
 #USAGE flag "-o --output <path>" help="Output file path" default="screenshot.png"
 set -euo pipefail
 
-IMAGE="${usage_image}"
+VM_NAME="${usage_vm:-}"
 OUTPUT="${usage_output}"
 
-VM_ID="$(basename "$IMAGE" .img)"
 WINNIE_RUN_DIR="${TMPDIR:-/tmp}/winnie"
+
+# If no VM specified, try to find exactly one running VM
+if [[ -z "$VM_NAME" ]]; then
+  socks=("$WINNIE_RUN_DIR"/*.sock)
+  live=()
+  for sock in "${socks[@]}"; do
+    [[ -S "$sock" ]] || continue
+    if printf '' | nc -U "$sock" >/dev/null 2>&1; then
+      live+=("$(basename "$sock" .sock)")
+    fi
+  done
+  if [[ ${#live[@]} -eq 0 ]]; then
+    echo "Error: no running VMs found." >&2
+    exit 1
+  elif [[ ${#live[@]} -gt 1 ]]; then
+    echo "Error: multiple VMs running. Specify one with --vm:" >&2
+    printf "  %s\n" "${live[@]}" >&2
+    exit 1
+  fi
+  VM_NAME="${live[0]}"
+fi
+
+# Derive VM_ID: strip common extensions, or use as-is
+VM_ID="$(basename "$VM_NAME")"
+VM_ID="${VM_ID%.img}"
+VM_ID="${VM_ID%.iso}"
+
 MONITOR_SOCK="$WINNIE_RUN_DIR/$VM_ID.sock"
 
 if [[ ! -S "$MONITOR_SOCK" ]]; then
@@ -21,12 +47,11 @@ fi
 OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
 
 # QEMU screendump supports PNG natively (Homebrew QEMU includes libpng)
-# Use nc -U (BSD netcat, ships with macOS) to send the monitor command
 printf 'screendump %s -f png\n' "$OUTPUT" | nc -U "$MONITOR_SOCK" >/dev/null 2>&1
 sleep 0.5
 
 if [[ ! -s "$OUTPUT" ]]; then
-  echo "Error: screenshot failed (empty or missing file)." >&2
+  echo "Error: screenshot failed (empty or missing file). Is a display device attached?" >&2
   exit 1
 fi
 

--- a/.mise/tasks/vm/screenshot
+++ b/.mise/tasks/vm/screenshot
@@ -17,7 +17,7 @@ if [[ -z "$VM_NAME" ]]; then
   live=()
   for sock in "${socks[@]}"; do
     [[ -S "$sock" ]] || continue
-    if printf '' | socat - UNIX-CONNECT:"$sock" >/dev/null 2>&1; then
+    if printf '' | socat - "UNIX-CONNECT:$sock" >/dev/null 2>&1; then
       live+=("$(basename "$sock" .sock)")
     fi
   done
@@ -49,7 +49,7 @@ fi
 OUTPUT="$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")"
 
 # QEMU screendump supports PNG natively (Homebrew QEMU includes libpng)
-printf 'screendump %s -f png\n' "$OUTPUT" | socat - UNIX-CONNECT:"$MONITOR_SOCK" >/dev/null 2>&1
+printf 'screendump %s -f png\n' "$OUTPUT" | socat - "UNIX-CONNECT:$MONITOR_SOCK" >/dev/null 2>&1
 sleep 0.5
 
 if [[ ! -s "$OUTPUT" ]]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -52,3 +52,62 @@ resolve_arch() {
       echo "$raw" ;;
   esac
 }
+
+# Normalize an architecture name to QEMU's canonical form.
+# Usage: normalize_arch <arch>
+# Accepts: arm64, aarch64, amd64, x86_64
+normalize_arch() {
+  case "$1" in
+    arm64|aarch64) echo "aarch64" ;;
+    amd64|x86_64)  echo "x86_64" ;;
+    *)             echo "$1" ;;
+  esac
+}
+
+# Select QEMU accelerator based on host arch, guest arch, and OS.
+# Usage: resolve_accel <host_arch> <guest_arch> <os>
+# Outputs: "hvf", "kvm", or "tcg,thread=multi"
+# host_arch and guest_arch should already be normalized.
+# os should be "Darwin" or "Linux".
+resolve_accel() {
+  local host="$1" guest="$2" os="$3"
+
+  if [[ "$host" == "$guest" ]]; then
+    case "$os" in
+      Darwin) echo "hvf"; return ;;
+      Linux)
+        if [[ -e /dev/kvm ]]; then
+          echo "kvm"; return
+        fi
+        ;;
+    esac
+  fi
+  echo "tcg,thread=multi"
+}
+
+# Select QEMU CPU model for a given guest architecture.
+# Usage: resolve_cpu <guest_arch> <accel>
+# For aarch64: "host" when using native accel, "cortex-a72" for emulation.
+# For x86_64: empty (QEMU's default is fine).
+resolve_cpu() {
+  local guest="$1" accel="$2"
+
+  case "$guest" in
+    aarch64)
+      if [[ "$accel" == "hvf" || "$accel" == "kvm" ]]; then
+        echo "host"
+      else
+        echo "cortex-a72"
+      fi
+      ;;
+  esac
+}
+
+# Select QEMU machine type for a given guest architecture.
+# Usage: resolve_machine <guest_arch>
+# aarch64 needs explicit "-machine virt". x86_64 uses QEMU's default.
+resolve_machine() {
+  case "$1" in
+    aarch64) echo "virt" ;;
+  esac
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -35,7 +35,8 @@ resolve_arch() {
       esac ;;
     pop-os)
       case "$raw" in
-        x86_64) echo "amd64" ;;
+        x86_64)  echo "amd64" ;;
+        aarch64) echo "arm64" ;;
         *) return 1 ;;
       esac ;;
     mint)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -17,13 +17,8 @@ spin() {
 # Returns empty string (and exits 1) if the distro doesn't support the arch.
 resolve_arch() {
   local distro="$1"
-  local raw="${2:-$(uname -m)}"
-
-  # Normalize: macOS says "arm64", Linux says "aarch64"
-  case "$raw" in
-    arm64|aarch64) raw="aarch64" ;;
-    x86_64|amd64)  raw="x86_64" ;;
-  esac
+  local raw
+  raw="$(normalize_arch "${2:-$(uname -m)}")"
 
   case "$distro" in
     alpine)

--- a/tests/test_resolve_arch.bats
+++ b/tests/test_resolve_arch.bats
@@ -62,9 +62,10 @@ setup() {
   [ "$output" = "amd64" ]
 }
 
-@test "resolve_arch pop-os aarch64 fails" {
+@test "resolve_arch pop-os aarch64 maps to arm64" {
   run resolve_arch pop-os aarch64
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 0 ]
+  [ "$output" = "arm64" ]
 }
 
 # --- mint (x86 only) ---

--- a/tests/test_vm.bats
+++ b/tests/test_vm.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+# Tests for VM-related helpers in lib/common.sh:
+# normalize_arch, resolve_accel, resolve_cpu, resolve_machine
+
+load test_helper
+
+setup() {
+  source "$MISE_CONFIG_ROOT/lib/common.sh"
+}
+
+# --- normalize_arch ---
+
+@test "normalize_arch arm64 → aarch64" {
+  run normalize_arch arm64
+  [ "$output" = "aarch64" ]
+}
+
+@test "normalize_arch aarch64 → aarch64" {
+  run normalize_arch aarch64
+  [ "$output" = "aarch64" ]
+}
+
+@test "normalize_arch amd64 → x86_64" {
+  run normalize_arch amd64
+  [ "$output" = "x86_64" ]
+}
+
+@test "normalize_arch x86_64 → x86_64" {
+  run normalize_arch x86_64
+  [ "$output" = "x86_64" ]
+}
+
+@test "normalize_arch unknown passes through" {
+  run normalize_arch riscv64
+  [ "$output" = "riscv64" ]
+}
+
+# --- resolve_accel ---
+
+@test "resolve_accel native on macOS → hvf" {
+  run resolve_accel aarch64 aarch64 Darwin
+  [ "$output" = "hvf" ]
+}
+
+@test "resolve_accel cross-arch on macOS → tcg" {
+  run resolve_accel aarch64 x86_64 Darwin
+  [ "$output" = "tcg,thread=multi" ]
+}
+
+@test "resolve_accel cross-arch on Linux → tcg" {
+  run resolve_accel x86_64 aarch64 Linux
+  [ "$output" = "tcg,thread=multi" ]
+}
+
+@test "resolve_accel x86_64 native on macOS → hvf" {
+  run resolve_accel x86_64 x86_64 Darwin
+  [ "$output" = "hvf" ]
+}
+
+# Note: kvm test is tricky — depends on /dev/kvm existing.
+# We test the fallback (no /dev/kvm) which is tcg.
+@test "resolve_accel native on Linux without kvm → tcg" {
+  # This test runs on macOS CI where /dev/kvm doesn't exist,
+  # so even with matching arches it falls through to tcg.
+  if [[ -e /dev/kvm ]]; then
+    skip "kvm available — would return kvm, not tcg"
+  fi
+  run resolve_accel x86_64 x86_64 Linux
+  [ "$output" = "tcg,thread=multi" ]
+}
+
+# --- resolve_cpu ---
+
+@test "resolve_cpu aarch64 with hvf → host" {
+  run resolve_cpu aarch64 hvf
+  [ "$output" = "host" ]
+}
+
+@test "resolve_cpu aarch64 with kvm → host" {
+  run resolve_cpu aarch64 kvm
+  [ "$output" = "host" ]
+}
+
+@test "resolve_cpu aarch64 with tcg → cortex-a72" {
+  run resolve_cpu aarch64 "tcg,thread=multi"
+  [ "$output" = "cortex-a72" ]
+}
+
+@test "resolve_cpu x86_64 → empty (QEMU default)" {
+  run resolve_cpu x86_64 hvf
+  [ "$output" = "" ]
+}
+
+@test "resolve_cpu x86_64 with tcg → empty" {
+  run resolve_cpu x86_64 "tcg,thread=multi"
+  [ "$output" = "" ]
+}
+
+# --- resolve_machine ---
+
+@test "resolve_machine aarch64 → virt" {
+  run resolve_machine aarch64
+  [ "$output" = "virt" ]
+}
+
+@test "resolve_machine x86_64 → empty (QEMU default)" {
+  run resolve_machine x86_64
+  [ "$output" = "" ]
+}


### PR DESCRIPTION
## Summary

- `vm:boot --arch <arch>` selects guest architecture (default: host)
- Auto-selects QEMU binary, accelerator (hvf/kvm/tcg), machine type, and CPU model
- ARM64 on Apple Silicon uses hvf for native speed; x86 on ARM falls back to tcg emulation
- UEFI firmware paths are arch-aware (OVMF for x86, AAVMF for aarch64)
- All decision logic extracted into testable functions in `lib/common.sh`
- 17 new tests covering `normalize_arch`, `resolve_accel`, `resolve_cpu`, `resolve_machine`

## Test plan

- [x] 93/93 tests pass (`mise run test`)
- [ ] Boot an ARM64 Alpine ISO natively on Apple Silicon (hvf)
- [ ] Boot an x86 ISO under emulation on Apple Silicon (tcg)
- [ ] Verify UEFI boot works for both arches

Part of #11 (multi-architecture VM support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)