### PR TITLE
feat: support Fedora Server installer ISOs

### DIFF
--- a/.mise/tasks/catalog/fedora
+++ b/.mise/tasks/catalog/fedora
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Show available Fedora Workstation versions"
+#MISE description="Show available Fedora versions and variants"
 #USAGE flag "-v --version <version>" help="Show variants for a specific version"
 #USAGE flag "--arch <arch>" help="Architecture (default: host)" default=""
 #USAGE flag "--json" help="Output as JSON"
@@ -8,27 +8,28 @@ set -euo pipefail
 MIRROR="https://dl.fedoraproject.org/pub/fedora/linux/releases"
 VERSION="${usage_version:-}"
 JSON="${usage_json:-false}"
-VARIANT="workstation"
 
 source "$MISE_CONFIG_ROOT/lib/common.sh"
 
-ARCH=$(resolve_arch fedora "${usage_arch:-}") || { echo "Error: Fedora Workstation does not publish ISOs for architecture '${usage_arch:-$(uname -m)}'." >&2; exit 1; }
+ARCH=$(resolve_arch fedora "${usage_arch:-}") || { echo "Error: Fedora does not publish ISOs for architecture '${usage_arch:-$(uname -m)}'." >&2; exit 1; }
 
-fetch_version_detail() {
-  local base html iso checksum_file checksum sha256 size
-  base="$MIRROR/$VERSION/Workstation/$ARCH/iso"
+emit_entry() {
+  local variant="$1" base="$2" iso_pattern="$3" checksum_pattern="$4"
+  local html iso checksum_file checksum sha256 size
 
-  html=$(curl -fsSL "$base/") || { echo "Error: Fedora $VERSION not found for $ARCH. This distro may not publish Workstation ISOs for this architecture." >&2; exit 1; }
-  iso=$(echo "$html" | sed -n 's/.*href="\(Fedora-Workstation-Live-[^"]*\.iso\)".*/\1/p' | head -1)
-  if [[ -z "$iso" ]]; then
-    echo "Error: no Fedora Workstation ISO found for $VERSION ($ARCH)." >&2
-    exit 1
+  if ! html=$(curl -fsSL "$base/" 2>/dev/null); then
+    return 0
   fi
 
-  checksum_file=$(echo "$html" | sed -n 's/.*href="\(Fedora-Workstation-[^"]*CHECKSUM\)".*/\1/p' | head -1)
+  iso=$(echo "$html" | sed -n "s/.*href=\"\\($iso_pattern\\)\".*/\\1/p" | head -1)
+  [[ -z "$iso" ]] && return 0
+
+  checksum_file=$(echo "$html" | sed -n "s/.*href=\"\\($checksum_pattern\\)\".*/\\1/p" | head -1)
   checksum=""
   if [[ -n "$checksum_file" ]]; then
-    checksum=$(curl -fsSL "$base/$checksum_file" 2>/dev/null || echo "")
+    if ! checksum=$(curl -fsSL "$base/$checksum_file" 2>/dev/null); then
+      checksum=""
+    fi
   fi
 
   sha256=$(echo "$checksum" | awk -v iso="$iso" '$2 == "(" iso ")" { print $4; exit }')
@@ -37,12 +38,29 @@ fetch_version_detail() {
 
   jq -n \
     --arg filename "$iso" \
-    --arg variant "$VARIANT" \
+    --arg variant "$variant" \
     --arg arch "$ARCH" \
     --arg url "$base/$iso" \
     --arg sha256 "$sha256" \
     --argjson size "$size" \
-    '[{filename: $filename, variant: $variant, arch: $arch, url: $url, sha256: $sha256, size: $size}]'
+    '{filename: $filename, variant: $variant, arch: $arch, url: $url, sha256: $sha256, size: $size}'
+}
+
+fetch_version_detail() {
+  {
+    emit_entry "workstation" \
+      "$MIRROR/$VERSION/Workstation/$ARCH/iso" \
+      'Fedora-Workstation-Live-[^"]*\.iso' \
+      'Fedora-Workstation-[^"]*CHECKSUM'
+    emit_entry "server-dvd" \
+      "$MIRROR/$VERSION/Server/$ARCH/iso" \
+      'Fedora-Server-dvd-[^"]*\.iso' \
+      'Fedora-Server-[^"]*CHECKSUM'
+    emit_entry "server-netinst" \
+      "$MIRROR/$VERSION/Server/$ARCH/iso" \
+      'Fedora-Server-netinst-[^"]*\.iso' \
+      'Fedora-Server-[^"]*CHECKSUM'
+  } | jq -s .
 }
 
 fetch_version_list() {
@@ -51,17 +69,17 @@ fetch_version_list() {
   echo "$html" \
     | sed -n 's/.*href="\([0-9][0-9]*\)\/".*/\1/p' \
     | sort -n -u \
-    | jq -R '{version: ., variants: ["workstation"]}' \
+    | jq -R '{version: ., variants: ["workstation", "server-dvd", "server-netinst"]}' \
     | jq -s 'sort_by(.version | tonumber)'
 }
 
 if [[ -n "$VERSION" ]]; then
-  entries=$(spin "Fetching Fedora $VERSION ($ARCH)..." bash -c "$(declare -f fetch_version_detail); VERSION='$VERSION' MIRROR='$MIRROR' ARCH='$ARCH' VARIANT='$VARIANT' fetch_version_detail")
+  entries=$(spin "Fetching Fedora $VERSION ($ARCH)..." bash -c "$(declare -f emit_entry fetch_version_detail); VERSION='$VERSION' MIRROR='$MIRROR' ARCH='$ARCH' fetch_version_detail")
 
   if [[ "$JSON" == "true" ]]; then
     echo "$entries" | jq .
   else
-    gum style --bold "Fedora Workstation $VERSION"
+    gum style --bold "Fedora $VERSION"
     echo ""
     echo "$entries" | jq -r '["Filename","Variant","Arch","Size"], (.[] | [.filename, .variant, .arch, ((.size / 1024 / 1024 | floor | tostring) + "MB")]) | @csv' \
       | tr -d '"' | gum table -p -w 55,14,10,10
@@ -72,9 +90,9 @@ else
   if [[ "$JSON" == "true" ]]; then
     echo "$entries" | jq .
   else
-    gum style --bold "Fedora Workstation — available versions"
+    gum style --bold "Fedora — available versions"
     echo ""
     echo "$entries" | jq -r '["Version","Variants"], (.[] | [.version, (.variants | join(" / "))]) | @csv' \
-      | tr -d '"' | gum table -p -w 10,20
+      | tr -d '"' | gum table -p -w 10,40
   fi
 fi

--- a/.mise/tasks/disk/add/device
+++ b/.mise/tasks/disk/add/device
@@ -64,7 +64,7 @@ if [[ -d "$DISTRO_DIR" ]]; then
 fi
 
 mkdir -p "$DISTRO_DIR"
-cp -r "$EXTRACT_DIR"/* "$DISTRO_DIR/"
+cp -R "$EXTRACT_DIR"/. "$DISTRO_DIR/"
 echo "  Copied files to /distros/$SLUG/"
 
 # --- Step 4: Regenerate grub.cfg ---

--- a/.mise/tasks/disk/add/image
+++ b/.mise/tasks/disk/add/image
@@ -85,7 +85,7 @@ if [[ -d "$DISTRO_DIR" ]]; then
 fi
 
 mkdir -p "$DISTRO_DIR"
-cp -r /extract/* "$DISTRO_DIR/"
+cp -R /extract/. "$DISTRO_DIR/"
 echo "  Copied files to /distros/$SLUG/"
 
 # --- Regenerate grub.cfg from all manifests ---

--- a/.mise/tasks/iso/extract
+++ b/.mise/tasks/iso/extract
@@ -98,24 +98,43 @@ if [[ -n "$INITRD_LINE" ]]; then
   INITRD_PATH=$(clean_grub_path "$(echo "$INITRD_LINE" | awk '{print $2}')")
 fi
 
-# --- Step 3: Find and extract squashfs ---
+# --- Step 3: Find payload files ---
 
-# Look for squashfs files in the ISO
-SQUASHFS_PATH=$(7zz l "$ISO" 2>/dev/null | awk 'tolower($NF) ~ /(filesystem\.squashfs|squashfs\.img)$/ && first == "" { first = $NF } END { if (first != "") print first }')
+ISO_LIST=$(7zz l "$ISO" 2>/dev/null)
+SQUASHFS_PATH=$(echo "$ISO_LIST" | awk 'tolower($NF) ~ /(filesystem\.squashfs|squashfs\.img)$/ && first == "" { first = $NF } END { if (first != "") print first }')
+INSTALL_IMG_PATH=$(echo "$ISO_LIST" | awk '$NF == "images/install.img" { print $NF; exit }')
+EXTRACT_MODE="flat"
+if [[ -n "$INSTALL_IMG_PATH" && "$BOOT_PARAMS" == *"inst.stage2="* ]]; then
+  EXTRACT_MODE="tree"
+fi
 
 # --- Step 4: Extract boot files ---
 
 KERNEL_FILENAME=$(basename "$KERNEL_PATH")
-7zz e "$ISO" "$KERNEL_PATH" -o"$OUTPUT" -y >/dev/null 2>&1
+INITRD_FILENAME=""
+SQUASHFS_FILENAME=""
+INSTALL_IMG_FILENAME=""
 
-if [[ -n "$INITRD_PATH" ]]; then
-  INITRD_FILENAME=$(basename "$INITRD_PATH")
-  7zz e "$ISO" "$INITRD_PATH" -o"$OUTPUT" -y >/dev/null 2>&1
+if [[ "$EXTRACT_MODE" == "tree" ]]; then
+  7zz x "$ISO" -o"$OUTPUT" -y >/dev/null 2>&1
+else
+  7zz e "$ISO" "$KERNEL_PATH" -o"$OUTPUT" -y >/dev/null 2>&1
+
+  if [[ -n "$INITRD_PATH" ]]; then
+    INITRD_FILENAME=$(basename "$INITRD_PATH")
+    7zz e "$ISO" "$INITRD_PATH" -o"$OUTPUT" -y >/dev/null 2>&1
+  fi
+
+  if [[ -n "$SQUASHFS_PATH" ]]; then
+    SQUASHFS_FILENAME=$(basename "$SQUASHFS_PATH")
+    7zz e "$ISO" "$SQUASHFS_PATH" -o"$OUTPUT" -y >/dev/null 2>&1
+  fi
 fi
 
-if [[ -n "$SQUASHFS_PATH" ]]; then
-  SQUASHFS_FILENAME=$(basename "$SQUASHFS_PATH")
-  7zz e "$ISO" "$SQUASHFS_PATH" -o"$OUTPUT" -y >/dev/null 2>&1
+if [[ "$EXTRACT_MODE" == "tree" ]]; then
+  [[ -n "$INITRD_PATH" ]] && INITRD_FILENAME=$(basename "$INITRD_PATH")
+  [[ -n "$SQUASHFS_PATH" ]] && SQUASHFS_FILENAME=$(basename "$SQUASHFS_PATH")
+  [[ -n "$INSTALL_IMG_PATH" ]] && INSTALL_IMG_FILENAME=$(basename "$INSTALL_IMG_PATH")
 fi
 
 # --- Step 5: Write manifest ---
@@ -126,16 +145,25 @@ jq -n \
   --arg initrd_path "${INITRD_PATH:-}" \
   --arg boot_params "$BOOT_PARAMS" \
   --arg squashfs_path "${SQUASHFS_PATH:-}" \
+  --arg install_img_path "${INSTALL_IMG_PATH:-}" \
+  --arg extract_mode "$EXTRACT_MODE" \
   '{
     title: $title,
     kernel_path: $kernel_path,
     initrd_path: $initrd_path,
     boot_params: $boot_params,
-    squashfs_path: $squashfs_path
+    squashfs_path: $squashfs_path,
+    install_img_path: $install_img_path,
+    extract_mode: $extract_mode
   }' > "$OUTPUT/manifest.json"
 
-echo "Extracted: $TITLE"
+if [[ "$EXTRACT_MODE" == "tree" ]]; then
+  echo "Extracted installer tree: $TITLE"
+else
+  echo "Extracted: $TITLE"
+fi
 echo "  Kernel:   $KERNEL_FILENAME"
 [[ -n "$INITRD_PATH" ]] && echo "  Initrd:   $INITRD_FILENAME"
 [[ -n "$SQUASHFS_PATH" ]] && echo "  Squashfs: $SQUASHFS_FILENAME"
+[[ -n "$INSTALL_IMG_PATH" ]] && echo "  Stage2:   $INSTALL_IMG_FILENAME"
 echo "  Manifest: $OUTPUT/manifest.json"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![tasks: mise](https://img.shields.io/badge/tasks-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 [![vm: QEMU](https://img.shields.io/badge/vm-QEMU-ff6600?style=flat&logo=qemu&logoColor=white)](https://www.qemu.org)
-[![tests: 175 passing](https://img.shields.io/badge/tests-175%20passing-blue?style=flat)](https://bats-core.readthedocs.io)
+[![tests: 177 passing](https://img.shields.io/badge/tests-177%20passing-blue?style=flat)](https://bats-core.readthedocs.io)
 
 </div>
 
@@ -102,7 +102,7 @@ Auto-discovered from `.mise/tasks/`. **This table updates when you add or rename
 | ----------------------- | ----------------------------------------------------------------- |
 | `winnie catalog:alpine` | Show available Alpine Linux versions and variants                 |
 | `winnie catalog:debian` | Show available Debian Live versions and variants                  |
-| `winnie catalog:fedora` | Show available Fedora Workstation versions                        |
+| `winnie catalog:fedora` | Show available Fedora versions and variants                       |
 | `winnie catalog:mint`   | Show available Linux Mint versions and variants                   |
 | `winnie catalog:pop-os` | Show available Pop!_OS versions and variants                      |
 | `winnie disk:add`       | Copy an ISO file onto a winnie disk                               |
@@ -209,4 +209,4 @@ Formatting a disk for a non-native architecture (e.g., x86_64 GRUB on an arm64 h
 mise run test
 ```
 
-175 tests across 12 BATS files — architecture helpers, GRUB generation, ISO extraction, disk format routing.
+177 tests across 12 BATS files — architecture helpers, GRUB generation, ISO extraction, disk format routing.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![tasks: mise](https://img.shields.io/badge/tasks-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 [![vm: QEMU](https://img.shields.io/badge/vm-QEMU-ff6600?style=flat&logo=qemu&logoColor=white)](https://www.qemu.org)
-[![tests: 177 passing](https://img.shields.io/badge/tests-177%20passing-blue?style=flat)](https://bats-core.readthedocs.io)
+[![tests: 179 passing](https://img.shields.io/badge/tests-179%20passing-blue?style=flat)](https://bats-core.readthedocs.io)
 
 </div>
 
@@ -209,4 +209,4 @@ Formatting a disk for a non-native architecture (e.g., x86_64 GRUB on an arm64 h
 mise run test
 ```
 
-177 tests across 12 BATS files — architecture helpers, GRUB generation, ISO extraction, disk format routing.
+179 tests across 12 BATS files — architecture helpers, GRUB generation, ISO extraction, disk format routing.

--- a/lib/grub-gen.sh
+++ b/lib/grub-gen.sh
@@ -18,13 +18,19 @@ GRUBHEAD
 
   for manifest in "$mount_point"/distros/*/manifest.json; do
     [[ -f "$manifest" ]] || continue
-    local dir slug title kernel initrd params
+    local dir slug title kernel initrd params extract_mode install_img
     dir=$(dirname "$manifest")
     slug=$(basename "$dir")
 
     title=$(jq -r '.title' "$manifest")
-    kernel=$(basename "$(jq -r '.kernel_path' "$manifest")")
-    initrd=$(basename "$(jq -r '.initrd_path' "$manifest")")
+    extract_mode=$(jq -r '.extract_mode // "flat"' "$manifest")
+    if [[ "$extract_mode" == "tree" ]]; then
+      kernel=$(jq -r '.kernel_path' "$manifest")
+      initrd=$(jq -r '.initrd_path' "$manifest")
+    else
+      kernel=$(basename "$(jq -r '.kernel_path' "$manifest")")
+      initrd=$(basename "$(jq -r '.initrd_path' "$manifest")")
+    fi
     params=$(jq -r '.boot_params' "$manifest")
 
     # Strip iso-specific params that don't apply to extracted boot
@@ -37,11 +43,21 @@ GRUBHEAD
     params=$(echo "$params" | sed 's|quiet||g; s|splash||g; s|\$extra_kernel_parameters||g' | sed 's/  */ /g; s/^ //; s/ $//')
     params="$params plymouth.enable=0"
 
-    # Ensure live-media pointers target the extracted location on the winnie drive.
-    # Debian/Ubuntu casper uses live-media-path; Fedora/dracut uses root=live + rd.live.dir.
+    # Ensure boot-media pointers target the extracted location on the winnie drive.
     local squashfs
     squashfs=$(jq -r '.squashfs_path // empty' "$manifest")
-    if [[ -n "$squashfs" ]]; then
+    install_img=$(jq -r '.install_img_path // empty' "$manifest")
+    if [[ -n "$install_img" ]]; then
+      if echo "$params" | grep -q 'inst.stage2='; then
+        # shellcheck disable=SC2001  # sed keeps the Anaconda boot-parameter rewrite readable
+        params=$(echo "$params" | sed "s|inst.stage2=[^ ]*|inst.stage2=hd:LABEL=WINNIE:/distros/$slug|g")
+      else
+        params="$params inst.stage2=hd:LABEL=WINNIE:/distros/$slug"
+      fi
+      if ! echo "$params" | grep -q 'inst.repo='; then
+        params="$params inst.repo=hd:LABEL=WINNIE:/distros/$slug"
+      fi
+    elif [[ -n "$squashfs" ]]; then
       if echo "$params" | grep -Eq '(^| )rd\.live\.image($| )|root=live:'; then
         if echo "$params" | grep -q 'root=live:'; then
           # shellcheck disable=SC2001  # sed keeps the boot-parameter rewrite readable

--- a/lib/grub-gen.sh
+++ b/lib/grub-gen.sh
@@ -54,7 +54,7 @@ GRUBHEAD
       else
         params="$params inst.stage2=hd:LABEL=WINNIE:/distros/$slug"
       fi
-      if ! echo "$params" | grep -q 'inst.repo='; then
+      if [[ -f "$dir/repodata/repomd.xml" ]] && ! echo "$params" | grep -q 'inst.repo='; then
         params="$params inst.repo=hd:LABEL=WINNIE:/distros/$slug"
       fi
     elif [[ -n "$squashfs" ]]; then

--- a/test/test_disk_add.bats
+++ b/test/test_disk_add.bats
@@ -42,6 +42,11 @@ setup() {
   [[ "$output" == *"does not exist"* ]]
 }
 
+@test "disk:add copy paths preserve hidden installer tree files" {
+  grep -Fq 'cp -R /extract/. "$DISTRO_DIR/"' "$REPO_DIR/.mise/tasks/disk/add/image"
+  grep -Fq 'cp -R "$EXTRACT_DIR"/. "$DISTRO_DIR/"' "$REPO_DIR/.mise/tasks/disk/add/device"
+}
+
 @test "disk:add --image fails if ISO too large for image" {
   dd if=/dev/zero of="$TEST_DIR/tiny.img" bs=1024 count=1 2>/dev/null
   dd if=/dev/zero of="$TEST_DIR/big.iso" bs=1024 count=2 2>/dev/null

--- a/test/test_grub_gen.bats
+++ b/test/test_grub_gen.bats
@@ -98,8 +98,10 @@ make_distro() {
   ! grep -q 'live-media-path=/distros/fedora' "$cfg"
 }
 
-@test "grub_generate rewrites Fedora Server stage2 and repo to extracted tree" {
+@test "grub_generate rewrites Fedora Server DVD stage2 and repo to extracted tree" {
   make_distro "fedora-server" "Install Fedora 42" "images/pxeboot/vmlinuz" "images/pxeboot/initrd.img" "inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-42 quiet" "" "images/install.img" "tree"
+  mkdir -p "$TEST_DIR/distros/fedora-server/repodata"
+  echo "fake-repodata" > "$TEST_DIR/distros/fedora-server/repodata/repomd.xml"
   grub_generate "$TEST_DIR"
   local cfg="$TEST_DIR/boot/grub/grub.cfg"
   grep -q 'linux /distros/fedora-server/images/pxeboot/vmlinuz' "$cfg"
@@ -107,6 +109,14 @@ make_distro() {
   grep -q 'inst.stage2=hd:LABEL=WINNIE:/distros/fedora-server' "$cfg"
   grep -q 'inst.repo=hd:LABEL=WINNIE:/distros/fedora-server' "$cfg"
   ! grep -q 'Fedora-S-dvd-x86_64-42' "$cfg"
+}
+
+@test "grub_generate does not add local repo for Fedora Server netinst without repodata" {
+  make_distro "fedora-netinst" "Install Fedora 42" "images/pxeboot/vmlinuz" "images/pxeboot/initrd.img" "inst.stage2=hd:LABEL=Fedora-S-netinst-x86_64-42 quiet" "" "images/install.img" "tree"
+  grub_generate "$TEST_DIR"
+  local cfg="$TEST_DIR/boot/grub/grub.cfg"
+  grep -q 'inst.stage2=hd:LABEL=WINNIE:/distros/fedora-netinst' "$cfg"
+  ! grep -q 'inst.repo=hd:LABEL=WINNIE:/distros/fedora-netinst' "$cfg"
 }
 
 @test "grub_generate does not add live-media-path when no squashfs" {

--- a/test/test_grub_gen.bats
+++ b/test/test_grub_gen.bats
@@ -11,7 +11,7 @@ setup() {
 
 # Helper: create a fake distro with a manifest
 make_distro() {
-  local slug="$1" title="$2" kernel="$3" initrd="$4" params="${5:-}" squashfs="${6:-}"
+  local slug="$1" title="$2" kernel="$3" initrd="$4" params="${5:-}" squashfs="${6:-}" install_img="${7:-}" extract_mode="${8:-flat}"
   local dir="$TEST_DIR/distros/$slug"
   mkdir -p "$dir"
   jq -n \
@@ -20,7 +20,9 @@ make_distro() {
     --arg initrd_path "$initrd" \
     --arg boot_params "$params" \
     --arg squashfs_path "$squashfs" \
-    '{title: $title, kernel_path: $kernel_path, initrd_path: $initrd_path, boot_params: $boot_params, squashfs_path: $squashfs_path}' \
+    --arg install_img_path "$install_img" \
+    --arg extract_mode "$extract_mode" \
+    '{title: $title, kernel_path: $kernel_path, initrd_path: $initrd_path, boot_params: $boot_params, squashfs_path: $squashfs_path, install_img_path: $install_img_path, extract_mode: $extract_mode}' \
     > "$dir/manifest.json"
 }
 
@@ -94,6 +96,17 @@ make_distro() {
   grep -q 'rd.live.dir=/distros/fedora' "$cfg"
   ! grep -q 'CDLABEL=Fedora-WS-Live-44' "$cfg"
   ! grep -q 'live-media-path=/distros/fedora' "$cfg"
+}
+
+@test "grub_generate rewrites Fedora Server stage2 and repo to extracted tree" {
+  make_distro "fedora-server" "Install Fedora 42" "images/pxeboot/vmlinuz" "images/pxeboot/initrd.img" "inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-42 quiet" "" "images/install.img" "tree"
+  grub_generate "$TEST_DIR"
+  local cfg="$TEST_DIR/boot/grub/grub.cfg"
+  grep -q 'linux /distros/fedora-server/images/pxeboot/vmlinuz' "$cfg"
+  grep -q 'initrd /distros/fedora-server/images/pxeboot/initrd.img' "$cfg"
+  grep -q 'inst.stage2=hd:LABEL=WINNIE:/distros/fedora-server' "$cfg"
+  grep -q 'inst.repo=hd:LABEL=WINNIE:/distros/fedora-server' "$cfg"
+  ! grep -q 'Fedora-S-dvd-x86_64-42' "$cfg"
 }
 
 @test "grub_generate does not add live-media-path when no squashfs" {

--- a/test/test_iso_extract.bats
+++ b/test/test_iso_extract.bats
@@ -185,6 +185,41 @@ EOF
   [ "$(jq -r '.squashfs_path' "$OUTPUT_DIR/manifest.json")" = "LiveOS/squashfs.img" ]
 }
 
+@test "iso:extract preserves Fedora Server installer tree" {
+  local root="$TEST_DIR/iso_root"
+  rm -rf "$root"
+  mkdir -p "$root/EFI/BOOT" "$root/images/pxeboot" "$root/images" "$root/repodata" "$root/Packages"
+
+  echo "fake-server-kernel" > "$root/images/pxeboot/vmlinuz"
+  echo "fake-server-initrd" > "$root/images/pxeboot/initrd.img"
+  echo "fake-server-stage2" > "$root/images/install.img"
+  echo "fake-treeinfo" > "$root/.treeinfo"
+  echo "fake-media-repo" > "$root/media.repo"
+  echo "fake-repodata" > "$root/repodata/repomd.xml"
+  echo "fake-package" > "$root/Packages/example.rpm"
+
+  cat > "$root/EFI/BOOT/grub.cfg" << 'EOF'
+menuentry 'Install Fedora 42' {
+    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-42 quiet
+    initrdefi /images/pxeboot/initrd.img
+}
+EOF
+
+  make_mock_iso "$TEST_DIR/test.iso" "$root"
+  run winnie iso:extract -- "$TEST_DIR/test.iso" --output "$OUTPUT_DIR"
+  [ "$status" -eq 0 ]
+  [ -f "$OUTPUT_DIR/images/pxeboot/vmlinuz" ]
+  [ -f "$OUTPUT_DIR/images/pxeboot/initrd.img" ]
+  [ -f "$OUTPUT_DIR/images/install.img" ]
+  [ -f "$OUTPUT_DIR/.treeinfo" ]
+  [ -f "$OUTPUT_DIR/media.repo" ]
+  [ -f "$OUTPUT_DIR/repodata/repomd.xml" ]
+  [ -f "$OUTPUT_DIR/Packages/example.rpm" ]
+  [ "$(jq -r '.title' "$OUTPUT_DIR/manifest.json")" = "Install Fedora 42" ]
+  [ "$(jq -r '.install_img_path' "$OUTPUT_DIR/manifest.json")" = "images/install.img" ]
+  [ "$(jq -r '.extract_mode' "$OUTPUT_DIR/manifest.json")" = "tree" ]
+}
+
 # --- error handling ---
 
 @test "iso:extract fails if ISO doesn't exist" {


### PR DESCRIPTION
## Summary

- extend `catalog:fedora` with `server-dvd` and `server-netinst` variants
- preserve Fedora Server installer trees during `iso:extract`
- rewrite Anaconda `inst.stage2` / `inst.repo` to the extracted Winnie distro directory
- keep Fedora Workstation live-media extraction behavior intact

Closes #37.

## Validation

- `mise run test`
- `codebase lint "$PWD"`
- `readme build --check`
- `git diff --check`
- `mise run catalog:fedora -- --version 42 --arch x86_64 --json`
- `WINNIE_ISO_DIR=~/.local/share/winnie/isos mise run iso:get fedora -v 42 --arch x86_64 --variant server-dvd`
- real `iso:extract` on `Fedora-Server-dvd-x86_64-42-1.1.iso`
- real `disk:format` + `disk:add` + `disk:inspect` on a Fedora Server-only Winnie image
