### PR TITLE
fix: preserve Fedora Server installer tree metadata

### DIFF
--- a/.mise/tasks/disk/add/device
+++ b/.mise/tasks/disk/add/device
@@ -64,7 +64,7 @@ if [[ -d "$DISTRO_DIR" ]]; then
 fi
 
 mkdir -p "$DISTRO_DIR"
-cp -r "$EXTRACT_DIR"/* "$DISTRO_DIR/"
+cp -R "$EXTRACT_DIR"/. "$DISTRO_DIR/"
 echo "  Copied files to /distros/$SLUG/"
 
 # --- Step 4: Regenerate grub.cfg ---

--- a/.mise/tasks/disk/add/image
+++ b/.mise/tasks/disk/add/image
@@ -85,7 +85,7 @@ if [[ -d "$DISTRO_DIR" ]]; then
 fi
 
 mkdir -p "$DISTRO_DIR"
-cp -r /extract/* "$DISTRO_DIR/"
+cp -R /extract/. "$DISTRO_DIR/"
 echo "  Copied files to /distros/$SLUG/"
 
 # --- Regenerate grub.cfg from all manifests ---

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![tasks: mise](https://img.shields.io/badge/tasks-mise-7c3aed?style=flat)](https://mise.jdx.dev)
 [![vm: QEMU](https://img.shields.io/badge/vm-QEMU-ff6600?style=flat&logo=qemu&logoColor=white)](https://www.qemu.org)
-[![tests: 177 passing](https://img.shields.io/badge/tests-177%20passing-blue?style=flat)](https://bats-core.readthedocs.io)
+[![tests: 179 passing](https://img.shields.io/badge/tests-179%20passing-blue?style=flat)](https://bats-core.readthedocs.io)
 
 </div>
 
@@ -209,4 +209,4 @@ Formatting a disk for a non-native architecture (e.g., x86_64 GRUB on an arm64 h
 mise run test
 ```
 
-177 tests across 12 BATS files — architecture helpers, GRUB generation, ISO extraction, disk format routing.
+179 tests across 12 BATS files — architecture helpers, GRUB generation, ISO extraction, disk format routing.

--- a/lib/grub-gen.sh
+++ b/lib/grub-gen.sh
@@ -54,7 +54,7 @@ GRUBHEAD
       else
         params="$params inst.stage2=hd:LABEL=WINNIE:/distros/$slug"
       fi
-      if ! echo "$params" | grep -q 'inst.repo='; then
+      if [[ -f "$dir/repodata/repomd.xml" ]] && ! echo "$params" | grep -q 'inst.repo='; then
         params="$params inst.repo=hd:LABEL=WINNIE:/distros/$slug"
       fi
     elif [[ -n "$squashfs" ]]; then

--- a/test/test_disk_add.bats
+++ b/test/test_disk_add.bats
@@ -42,6 +42,11 @@ setup() {
   [[ "$output" == *"does not exist"* ]]
 }
 
+@test "disk:add copy paths preserve hidden installer tree files" {
+  grep -Fq 'cp -R /extract/. "$DISTRO_DIR/"' "$REPO_DIR/.mise/tasks/disk/add/image"
+  grep -Fq 'cp -R "$EXTRACT_DIR"/. "$DISTRO_DIR/"' "$REPO_DIR/.mise/tasks/disk/add/device"
+}
+
 @test "disk:add --image fails if ISO too large for image" {
   dd if=/dev/zero of="$TEST_DIR/tiny.img" bs=1024 count=1 2>/dev/null
   dd if=/dev/zero of="$TEST_DIR/big.iso" bs=1024 count=2 2>/dev/null

--- a/test/test_grub_gen.bats
+++ b/test/test_grub_gen.bats
@@ -98,8 +98,10 @@ make_distro() {
   ! grep -q 'live-media-path=/distros/fedora' "$cfg"
 }
 
-@test "grub_generate rewrites Fedora Server stage2 and repo to extracted tree" {
+@test "grub_generate rewrites Fedora Server DVD stage2 and repo to extracted tree" {
   make_distro "fedora-server" "Install Fedora 42" "images/pxeboot/vmlinuz" "images/pxeboot/initrd.img" "inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-42 quiet" "" "images/install.img" "tree"
+  mkdir -p "$TEST_DIR/distros/fedora-server/repodata"
+  echo "fake-repodata" > "$TEST_DIR/distros/fedora-server/repodata/repomd.xml"
   grub_generate "$TEST_DIR"
   local cfg="$TEST_DIR/boot/grub/grub.cfg"
   grep -q 'linux /distros/fedora-server/images/pxeboot/vmlinuz' "$cfg"
@@ -107,6 +109,14 @@ make_distro() {
   grep -q 'inst.stage2=hd:LABEL=WINNIE:/distros/fedora-server' "$cfg"
   grep -q 'inst.repo=hd:LABEL=WINNIE:/distros/fedora-server' "$cfg"
   ! grep -q 'Fedora-S-dvd-x86_64-42' "$cfg"
+}
+
+@test "grub_generate does not add local repo for Fedora Server netinst without repodata" {
+  make_distro "fedora-netinst" "Install Fedora 42" "images/pxeboot/vmlinuz" "images/pxeboot/initrd.img" "inst.stage2=hd:LABEL=Fedora-S-netinst-x86_64-42 quiet" "" "images/install.img" "tree"
+  grub_generate "$TEST_DIR"
+  local cfg="$TEST_DIR/boot/grub/grub.cfg"
+  grep -q 'inst.stage2=hd:LABEL=WINNIE:/distros/fedora-netinst' "$cfg"
+  ! grep -q 'inst.repo=hd:LABEL=WINNIE:/distros/fedora-netinst' "$cfg"
 }
 
 @test "grub_generate does not add live-media-path when no squashfs" {


### PR DESCRIPTION
## Summary

- copy extracted installer trees with `cp -R src/. dest/` so dotfiles like `.treeinfo` survive `disk:add`
- only add local `inst.repo=hd:LABEL=WINNIE:/distros/<slug>` when the extracted Fedora installer tree has local repo metadata
- add regression coverage for hidden tree files and Fedora Server netinst-without-repodata behavior

## Why

`winnie#38` makes `iso:extract` preserve Fedora Server installer trees, including `.treeinfo`, but the existing `disk:add` copy path used `*` globs and would drop that dotfile before regenerating GRUB. The PR also catalogs `server-netinst`; netinst media should get local `inst.stage2` but should not be forced to use a local package repo unless `repodata/repomd.xml` exists.

## Validation

- `bash -n .mise/tasks/disk/add/image .mise/tasks/disk/add/device lib/grub-gen.sh test/test_disk_add.bats test/test_grub_gen.bats`
- manual `cp -R src/. dest/` smoke with `.treeinfo`
- `mise run test disk_add`
- `mise run test grub_gen`
- `mise run test`
- `codebase lint "$PWD"`
- `readme build --check`
- `git diff --check`
